### PR TITLE
tweak wording on a few pages

### DIFF
--- a/2016/app/components/About.js
+++ b/2016/app/components/About.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function About() {
+  return (
+    <p>
+    React Rally is a two day single track conference for developers of all backgrounds using Facebook's React.js, React Native, and related tools.
+    Speakers will cover topics such as React Native, Flux, ES6, <del>isomorphic</del> universal JavaScript, and so much more.
+    Whether you're a seasoned developer who has been using React since before it was cool, or a newcomer to the scene, React Rally has something for everyone!
+    </p>
+  )
+}

--- a/2016/app/components/Header.js
+++ b/2016/app/components/Header.js
@@ -9,7 +9,7 @@ export default class Header extends Component {
     super(props);
     this.state = {isNavActive: false}
   }
-  
+
   handleNavClick() {
     this.setState({isNavActive: !this.state.isNavActive})
   }
@@ -25,9 +25,9 @@ export default class Header extends Component {
             <div className="Home__Header__Content">
               <h1>August 25-26 in Salt Lake City, UT</h1>
               <p>
-                Facebook's ReactJS has taken client side development by storm.
-                From single-page apps, to server rendering, to native mobile, to apps on your TV, ReactJS is everywhere.
-                Come find out what makes it so incredible.
+                Facebook's React has taken client side development by storm.
+                From single-page apps, to server rendering, to native mobile, to apps on your TV, React is everywhere.
+                Come hear from the best and the brightest in the React community about what makes it so incredible.
               </p>
               <div className="Home__Header__Buttons">
                 <Button href={constants.Links.TICKET_SALES} className="large">Register Now</Button>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/2016/app/screens/About/index.js
+++ b/2016/app/screens/About/index.js
@@ -1,12 +1,13 @@
 import React from 'react'
+import About from 'components/About'
 import Avatar from 'components/Avatar'
 import Legend from 'components/Legend'
 
 export default () => {
   return (
     <div className="About">
-      <h1>About React Rally</h1>
-      <p>React Rally is a two day, single track conference for developers of all backgrounds using Facebook's ReactJS. Speakers will cover topics such as React Native, Flux, ES6, Isomorphic JavaScript, and so much more. Whether you're a seasoned developer, or a fledgling newbie. Whether you have been using React since it was first announced, or are just getting started. React Rally has something for everyone!</p>
+      <h2>About React Rally</h2>
+      <About />
       <div className="align-center">
         <Legend>Organizers</Legend>
         <Avatar name="Matt Zabriskie" title="Co-organizer" url="https://avatars2.githubusercontent.com/u/199035"/>

--- a/2016/app/screens/Home/index.js
+++ b/2016/app/screens/Home/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router'
+import About from 'components/About'
 import Avatar from 'components/Avatar'
 import Button from 'components/Button'
 import Legend from 'components/Legend'
@@ -9,13 +10,7 @@ export default () => {
     <div className="Home">
       <div>
         <h2>What is React Rally?</h2>
-        <p>
-          React Rally is a two day, single track conference for developers of all backgrounds using Facebook's ReactJS.
-          Speakers will cover topics such as React Native, Flux, ES6, Isomorphic JavaScript, and so much more.
-          Whether you're a seasoned developer, or a fledgling newbie.
-          Whether you have been using React since it was first announced, or are just getting started.
-          React Rally has something for everyone!
-        </p>
+        <About />
         <Link to="/about" className="Button medium">More about React Rally &raquo;</Link>
       </div>
       <div className="align-center">

--- a/2016/app/screens/Proposals/index.js
+++ b/2016/app/screens/Proposals/index.js
@@ -4,22 +4,28 @@ import Button from 'components/Button'
 
 export default () => {
   return (
-    <div className="Proposals" style={{textAlign: 'center'}}>
-      <h1>React Rally 2016 CFP is open until April 27th. If you're doing something interesting with React we'd love to hear about it!</h1>
-      <p>This year we really want to hear about how the community is using React. Specifically we would love to hear about projects that are using React in unconventional or unexpected ways. Some ideas for what we would like to hear about are:</p>
-      <ul style={{textAlign: 'left', margin: '0 auto', display: 'inline-block'}}>
-        <li>WebGL</li>
-        <li>Virtual Reality</li>
-        <li>Video Games</li>
-        <li>Robotics</li>
-        <li>Embeded Devices</li>
-        <li>Foreign Platforms</li>
-        <li>etc.</li>
-      </ul>
-      <p>Of course if you have a more conventional talk you'd like to submit, we'd love to accept that too.</p>
-      <p>If you would like to discuss your proposal, get some feedback, or brainstorm an idea, feel free to ask <a href="mailto:team@reactrally.com">team@reactrally.com</a>.</p>
-      <p>&nbsp;</p>
+    <div className="Proposals">
+      <h1>The React Rally 2016 CFP is open until April 27th. If you're doing something interesting with React we'd love to hear about it!</h1>
       <Button href={constants.Links.PROPOSAL_FORM}>Submit Proposal &raquo;</Button>
+      <p>
+        We want React Rally to showcase how the wider community is using React. We want stories about products or experiences that React made possible, stories about overcoming challenges with React, and ideas for solving problems that exist in React today. We are interested in hearing how you are pushing the limits of React, and how we can all use React to build better stuff. We want speakers of all experience levels and backgrounds, because React is for people of all experience levels and background.
+      </p>
+
+      <p>No idea what to talk about? Here are some ideas that could be interesting (but we are in no way limiting suggestions to this list of ideas).</p>
+      <ul style={{textAlign: 'left', margin: '0 auto', display: 'inline-block'}}>
+        <li>Observables and React</li>
+        <li>Rendering to non-DOM targets (A React-to-Minecraft renderer? Why not?)</li>
+        <li>Managing asynchronous Flux/Redux state</li>
+        <li>What React can learn from other frameworks</li>
+        <li>Pitfalls in building reusable React components</li>
+        <li>The ideas of React throughout the history of computing</li>
+        <li>React and art</li>
+        <li>Server-rendered React using AWS Lambda</li>
+        <li>Teaching React to beginners</li>
+        <li>Learning React as a junior developer</li>
+      </ul>
+      <p>Of course if you have another talk you'd like to submit, we'd love to see that too.</p>
+      <p>If you would like to discuss your proposal, get some feedback, or brainstorm an idea, feel free to ask <a href="mailto:team@reactrally.com">team@reactrally.com</a>.</p>
     </div>
   )
 }

--- a/2016/app/screens/Schedule/index.js
+++ b/2016/app/screens/Schedule/index.js
@@ -4,6 +4,7 @@ export default () => {
   return (
     <div className="Schedule">
       <h1>Schedule</h1>
+      <p>It turns out you need speakers to have a schedule. More details coming soon!</p>
     </div>
   )
 }

--- a/2016/app/screens/Speakers/index.js
+++ b/2016/app/screens/Speakers/index.js
@@ -4,6 +4,7 @@ export default () => {
   return (
     <div className="Speakers">
       <h1>Speakers</h1>
+      <p>Look for a schedule after the talks are accepted!</p>
     </div>
   )
 }

--- a/2016/assets/css/styles.scss
+++ b/2016/assets/css/styles.scss
@@ -330,7 +330,6 @@ ul.navigation {
   left: 50%;
   bottom: -43px;
   margin-left: -42px;
-  display: none;
 }
 .Avatar__Social .Icon {
   border-width: 0;


### PR DESCRIPTION
I changed the wording quite a bit on the Proposal page. The rest of it is smaller tweaks.

The only style thing I changed was making the github and twitter buttons always appear on avatars. It felt weird to me that hovering over the avatar would make the buttons appear, but hovering over the place where the buttons would show up would not make the buttons appear.

Also, since the diff is a bit hard to read, here is what the Proposal page looks like now:

<img width="1440" alt="screen shot 2016-03-22 at 11 42 50 pm" src="https://cloud.githubusercontent.com/assets/72027/13976677/ce50692c-f087-11e5-8469-cfada1f414ee.png">
