### PR TITLE
Fix social links, reuse speaker data for home page

### DIFF
--- a/2016/app/screens/About/index.js
+++ b/2016/app/screens/About/index.js
@@ -14,15 +14,15 @@ export default () => {
           name="Matt Zabriskie"
           title="Co-organizer"
           url="https://avatars2.githubusercontent.com/u/199035"
-          twitter="https://twitter.com/mzabriskie"
-          github="https://github.com/mzabriskie"
+          twitter="mzabriskie"
+          github="mzabriskie"
         />
         <Avatar
           name="Jamison Dance"
           title="Co-organizer"
           url="https://avatars0.githubusercontent.com/u/72027"
-          twitter="https://twitter.com/jergason"
-          github="https://github.com/jergason"
+          twitter="jergason"
+          github="jergason"
         />
       </div>
     </div>

--- a/2016/app/screens/Home/index.js
+++ b/2016/app/screens/Home/index.js
@@ -4,6 +4,15 @@ import About from 'components/About'
 import Avatar from 'components/Avatar'
 import Button from 'components/Button'
 import Legend from 'components/Legend'
+import SpeakerData from '../../../api/speakers'
+
+const KEYNOTE_SPEAKERS = [
+  'ryanflorence',
+  'marcysutton',
+  'sarah_edo',
+  'zpao',
+  'en_JS',
+];
 
 export default () => {
   return (
@@ -15,41 +24,10 @@ export default () => {
       </div>
       <div className="align-center">
         <Legend>Keynote Speakers</Legend>
-        <Avatar
-          name="Ryan Florence"
-          title="Co-founder, React Training"
-          url="https://avatars0.githubusercontent.com/u/100200"
-          twitter="https://twitter.com/ryanflorence"
-          github="https://github.com/ryanflorence"
-        />
-        <Avatar
-          name="Marcy Sutton"
-          title="Sr. Front-End Engineer, Deque Systems"
-          url="https://avatars0.githubusercontent.com/u/1045233"
-          twitter="https://twitter.com/marcysutton"
-          github="https://github.com/marcysutton"
-        />
-        <Avatar
-          name="Sarah Drasner"
-          title="Manager, UX Design & Engineering, Trulia"
-          url="https://s3-us-west-2.amazonaws.com/s.cdpn.io/28963/bio-pic.jpg"
-          twitter="https://twitter.com/sarah_edo"
-          github="https://github.com/sdras"
-        />
-        <Avatar
-          name="Paul O’Shannessy"
-          title="React Core Team, Facebook"
-          url="https://avatars0.githubusercontent.com/u/8445?v=3&s=460"
-          twitter="https://twitter.com/zpao"
-          github="https://github.com/zpao"
-        />
-        <Avatar
-          name="Joseph Savona"
-          title="Relay & GraphQL Core Team, Facebook"
-          url="https://avatars2.githubusercontent.com/u/6425824?v=3&s=460"
-          twitter="https://twitter.com/en_JS"
-          github="https://github.com/josephsavona"
-        />
+        {KEYNOTE_SPEAKERS.map(key => {
+          let speaker = SpeakerData[key]
+          return <Avatar {...speaker} url={speaker.avatar} key={key}/>
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
- `<Avatar/>` takes usernames for twitter, github so these links were all
  broken.
- Also reused the speaker data for the home page in case there are more
  bio (or other) updates
