### PR TITLE
fix timezone issues with date countdown

### DIFF
--- a/2017/app/helpers/DateUtils.js
+++ b/2017/app/helpers/DateUtils.js
@@ -4,19 +4,17 @@ class DateUtils {
   }
 
   createDate(...args) {
-    let date = new Date(...args)
-    let tzOffset = date.getTimezoneOffset() * DateUtils.MINUTES
-    return new Date((date.getTime() + tzOffset) - (this.tzOffset * DateUtils.MINUTES))
+    return new Date(...args)
   }
 
   getTime() {
     return this.createDate().getTime()
   }
-  
+
   isDateToday(date) {
     return this.createDate().toDateString() === date.toDateString()
   }
-  
+
   isNowAfterTime(time) {
     return this.getTime() >= time
   }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ```bash
 git clone git@github.com:react-rally/www.git react-rally
 cd react-rally
-npm install
 cd [YEAR]
+npm install
 npm start
 open http://127.0.0.1:8080
 ```


### PR DESCRIPTION
Right now on reactrally.com, if you change your system timezone from mountain to any other time, the countdown timer gets messed up. This fixes the countdown timer to show the correct amount of time remaining until tickets go on sale.

How to test:

1. Open System Preferences -> Date & Time
2. Click the Time Zone tab
3. Uncheck the "set date and time automatically" box
4. Pick any other timezone besides mountain
5. Go to www.reactrally.com, and notice the countdown is wrong
6. Run this branch locally, and notice it is correct